### PR TITLE
Better way to load azd env variables

### DIFF
--- a/scripts/auth_common.py
+++ b/scripts/auth_common.py
@@ -1,0 +1,23 @@
+import json
+import logging
+import subprocess
+
+from dotenv import load_dotenv
+
+logger = logging.getLogger("authsetup")
+
+
+def load_azd_env():
+    """Get path to current azd env file and load file using python-dotenv"""
+    result = subprocess.run("azd env list -o json", shell=True, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise Exception("Error loading azd env")
+    env_json = json.loads(result.stdout)
+    env_file_path = None
+    for entry in env_json:
+        if entry["IsDefault"]:
+            env_file_path = entry["DotEnvPath"]
+    if not env_file_path:
+        raise Exception("No default azd env file found")
+    logger.info(f"Loading azd env from {env_file_path}")
+    load_dotenv(env_file_path, override=True)

--- a/scripts/auth_init.ps1
+++ b/scripts/auth_init.ps1
@@ -3,8 +3,6 @@ if ($env:GITHUB_ACTIONS) {
   exit 0
 }
 
-. ./scripts/load_env.ps1
-
 $pythonCmd = Get-Command python -ErrorAction SilentlyContinue
 if (-not $pythonCmd) {
   # fallback to python3 if python not found

--- a/scripts/auth_init.py
+++ b/scripts/auth_init.py
@@ -1,7 +1,9 @@
 import asyncio
+import logging
 import os
 import subprocess
 
+from auth_common import load_azd_env
 from azure.identity import AzureDeveloperCliCredential
 from kiota_abstractions.api_error import APIError
 from msgraph import GraphServiceClient
@@ -12,6 +14,13 @@ from msgraph.generated.models.application import Application
 from msgraph.generated.models.implicit_grant_settings import ImplicitGrantSettings
 from msgraph.generated.models.password_credential import PasswordCredential
 from msgraph.generated.models.web_application import WebApplication
+from rich.logging import RichHandler
+
+logging.basicConfig(
+    level=logging.WARNING, format="%(message)s", handlers=[RichHandler(rich_tracebacks=True, log_time_format="")]
+)
+logger = logging.getLogger("authsetup")
+logger.setLevel(logging.INFO)
 
 
 async def check_for_application(client: GraphServiceClient, app_id: str) -> bool:
@@ -47,7 +56,7 @@ def update_azd_env(name, val):
 
 
 async def main():
-    print("Setting up authentication...")
+    logger.info("Setting up authentication...")
     tenant_id = os.getenv("AZURE_AUTH_TENANT_ID")
     auth_credential = AzureDeveloperCliCredential(tenant_id=tenant_id)
 
@@ -56,22 +65,23 @@ async def main():
 
     app_id = os.getenv("AZURE_AUTH_APP_ID", "no-id")
     if app_id != "no-id":
-        print(f"Checking if application {app_id} exists")
+        logger.info(f"Checking if application {app_id} exists")
         if await check_for_application(client, app_id):
-            print("Application already exists, not creating new one")
+            logger.info("Application already exists, not creating new one")
             exit(0)
 
-    print("Creating application registration")
+    logger.info("Creating application registration")
     app = await create_application(client)
 
-    print(f"Adding client secret to {app.id}")
+    logger.info(f"Adding client secret to {app.id}")
     client_secret = await add_client_secret(client, app.id)
 
-    print("Updating azd env with AZURE_AUTH_APP_ID, AZURE_AUTH_CLIENT_ID, AZURE_AUTH_CLIENT_SECRET")
+    logger.info("Updating azd env with AZURE_AUTH_APP_ID, AZURE_AUTH_CLIENT_ID, AZURE_AUTH_CLIENT_SECRET")
     update_azd_env("AZURE_AUTH_APP_ID", app.id)
     update_azd_env("AZURE_AUTH_CLIENT_ID", app.app_id)
     update_azd_env("AZURE_AUTH_CLIENT_SECRET", client_secret)
 
 
 if __name__ == "__main__":
+    load_azd_env()
     asyncio.run(main())

--- a/scripts/auth_init.sh
+++ b/scripts/auth_init.sh
@@ -5,6 +5,4 @@ if [ -n "$GITHUB_ACTIONS" ]; then
   exit 0
 fi
 
-. ./scripts/load_env.sh
-
 python ./scripts/auth_init.py

--- a/scripts/auth_update.ps1
+++ b/scripts/auth_update.ps1
@@ -3,8 +3,6 @@ if ($env:GITHUB_ACTIONS) {
   exit 0
 }
 
-. ./scripts/load_env.ps1
-
 $pythonCmd = Get-Command python -ErrorAction SilentlyContinue
 if (-not $pythonCmd) {
   # fallback to python3 if python not found

--- a/scripts/auth_update.py
+++ b/scripts/auth_update.py
@@ -1,11 +1,20 @@
 import asyncio
+import logging
 import os
 import subprocess
 
+from auth_common import load_azd_env
 from azure.identity import AzureDeveloperCliCredential
 from msgraph import GraphServiceClient
 from msgraph.generated.models.application import Application
 from msgraph.generated.models.web_application import WebApplication
+from rich.logging import RichHandler
+
+logging.basicConfig(
+    level=logging.WARNING, format="%(message)s", handlers=[RichHandler(rich_tracebacks=True, log_time_format="")]
+)
+logger = logging.getLogger("authsetup")
+logger.setLevel(logging.INFO)
 
 
 async def update_redirect_uris(client: GraphServiceClient, app_id: str, uri: str):
@@ -16,19 +25,20 @@ async def update_redirect_uris(client: GraphServiceClient, app_id: str, uri: str
 
 
 async def main():
-    print("Clearing secret from environment (now that it's stored in KeyVault)...")
+    logger.info("Clearing secret from environment (now that it's stored in KeyVault)...")
     subprocess.run('azd env set AZURE_AUTH_CLIENT_SECRET ""', shell=True)
 
-    print("Updating authentication...")
+    logger.info("Updating authentication...")
     credential = AzureDeveloperCliCredential(tenant_id=os.getenv("AZURE_AUTH_TENANT_ID"))
     scopes = ["https://graph.microsoft.com/.default"]
     client = GraphServiceClient(credentials=credential, scopes=scopes)
 
     app_id = os.getenv("AZURE_AUTH_APP_ID")
     uri = os.getenv("AZURE_AUTH_REDIRECT_URI")
-    print(f"Updating application registration {app_id} with redirect URI for {uri}")
+    logger.info(f"Updating application registration {app_id} with redirect URI for {uri}")
     await update_redirect_uris(client, app_id, uri)
 
 
 if __name__ == "__main__":
+    load_azd_env()
     asyncio.run(main())

--- a/scripts/auth_update.sh
+++ b/scripts/auth_update.sh
@@ -5,6 +5,4 @@ if [ -n "$GITHUB_ACTIONS" ]; then
   exit 0
 fi
 
-. ./scripts/load_env.sh
-
 python ./scripts/auth_update.py

--- a/scripts/load_env.ps1
+++ b/scripts/load_env.ps1
@@ -1,7 +1,0 @@
-foreach ($line in (& azd env get-values)) {
-    if ($line -match "([^=]+)=(.*)") {
-        $key = $matches[1]
-        $value = $matches[2] -replace '^"|"$'
-	    [Environment]::SetEnvironmentVariable($key, $value)
-    }
-}

--- a/scripts/load_env.sh
+++ b/scripts/load_env.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-while IFS='=' read -r key value; do
-    value=$(echo "$value" | sed 's/^"//' | sed 's/"$//')
-    export "$key=$value"
-done <<EOF
-$(azd env get-values)
-EOF

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,4 @@
 azure-identity
 msgraph-sdk
+rich
+python-dotenv


### PR DESCRIPTION
## Purpose

Moves to a safer way to load azd env variables.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[X] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/rag-postgres-openai-python/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` manually on my code.
