### PR TITLE
Revert app factory

### DIFF
--- a/src/gunicorn.conf.py
+++ b/src/gunicorn.conf.py
@@ -3,7 +3,7 @@ import os
 
 from dotenv import load_dotenv
 
-load_dotenv()
+load_dotenv(override=True)
 
 max_requests = 1000
 max_requests_jitter = 50

--- a/src/quartapp/__init__.py
+++ b/src/quartapp/__init__.py
@@ -1,6 +1,7 @@
 import logging
 import os
 
+from dotenv import load_dotenv
 from quart import Quart
 
 
@@ -9,16 +10,10 @@ def create_app():
         logging.basicConfig(level=logging.WARNING)
     else:
         logging.basicConfig(level=logging.INFO)
+        load_dotenv(verbose=True, override=True)
 
     app = Quart(__name__)
     app.logger.setLevel(logging.INFO)
-
-    from .auth import auth
-
-    # Declare the session type first, for the Auth extension to work with Quart-Session properly:
-    app.config["SESSION_TYPE"] = "redis"
-    # Initialize the Auth extension with the Quart app instance:
-    auth.init_app(app)
 
     from . import chat  # noqa
 

--- a/src/quartapp/auth.py
+++ b/src/quartapp/auth.py
@@ -12,7 +12,7 @@ def get_redirect_uri():
         redirect_uri = (
             f"https://{os.environ['CONTAINER_APP_NAME']}.{os.environ['CONTAINER_APP_ENV_DNS_SUFFIX']}/redirect"
         )
-        logging.warn(f"Using production redirect URI: {redirect_uri}")
+        logging.info(f"Using production redirect URI: {redirect_uri}")
     return redirect_uri
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import identity.quart
 import openai
 import pytest
 import pytest_asyncio
-from azure.keyvault.secrets import SecretClient
+from azure.keyvault.secrets.aio import SecretClient
 
 import quartapp
 
@@ -126,8 +126,7 @@ def mock_openai_chatcompletion(monkeypatch):
 
 @pytest.fixture
 def mock_defaultazurecredential(monkeypatch):
-    monkeypatch.setattr("azure.identity.DefaultAzureCredential", mock_cred.MockAzureCredential)
-    monkeypatch.setattr("azure.identity.aio.DefaultAzureCredential", mock_cred.MockAsyncAzureCredential)
+    monkeypatch.setattr("azure.identity.aio.DefaultAzureCredential", mock_cred.MockAzureCredential)
 
 
 @pytest.fixture
@@ -135,7 +134,7 @@ def mock_keyvault_secretclient(monkeypatch):
     monkeypatch.setenv("AZURE_KEY_VAULT_NAME", "my_key_vault")
     monkeypatch.setenv("AZURE_AUTH_CLIENT_SECRET_NAME", "my_secret_name")
 
-    def get_secret(*args, **kwargs):
+    async def get_secret(*args, **kwargs):
         if args[1] == "my_secret_name":
             return mock_cred.MockKeyVaultSecret("mysecret")
         raise Exception(f"Unexpected secret name: {args[1]}")

--- a/tests/mock_cred.py
+++ b/tests/mock_cred.py
@@ -1,11 +1,7 @@
 import azure.core.credentials_async
 
 
-class MockAsyncAzureCredential(azure.core.credentials_async.AsyncTokenCredential):
-    pass
-
-
-class MockAzureCredential(azure.core.credentials.TokenCredential):
+class MockAzureCredential(azure.core.credentials_async.AsyncTokenCredential):
     pass
 
 


### PR DESCRIPTION
## Purpose

There was an issue in production with Redis, where it claimed to be setting up Azure redis, but a call was made to a local Redis. So I am reverting back to my previous approach.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/rag-postgres-openai-python/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [x] I added tests that prove my fix is effective or that my feature works
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [x] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` manually on my code.
