### PR TITLE
Update ubuntu runner to latest (pinned one was deprecated)

### DIFF
--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04"]
+        os: ["ubuntu-latest"]
         python_version: ["3.10", "3.11", "3.12"]
     steps:
         - uses: actions/checkout@v4


### PR DESCRIPTION
## Purpose

This pull request updates the GitHub Actions workflow to use the latest Ubuntu version for Python checks.

* [`.github/workflows/python-check.yaml`](diffhunk://#diff-66643ae2ed0dc6605cfbfa5305ab053d24b7214270f1c960cd49bd35870b0e2aL25-R25): Updated the `os` matrix in the strategy section from `["ubuntu-20.04"]` to `["ubuntu-latest"]` to ensure the workflow runs on the most up-to-date Ubuntu version.


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/rag-postgres-openai-python/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` manually on my code.
