### PR TITLE
Migrate from Chat Completions to Responses API with gpt-5.2

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -40,15 +40,15 @@ param name string
 param location string
 
 @description('Name of the GPT model to deploy')
-param gptModelName string = 'gpt-4o-mini'
+param gptModelName string = 'gpt-5.2-chat'
 
 @description('Version of the GPT model to deploy')
 // See version availability in this table:
 // https://learn.microsoft.com/azure/ai-services/openai/concepts/models?tabs=python-secure%2Cglobal-standard%2Cstandard-chat-completions#models-by-deployment-type
-param gptModelVersion string = '2024-07-18'
+param gptModelVersion string = '2026-02-10'
 
 @description('Name of the model deployment (can be different from the model name)')
-param gptDeploymentName string = 'gpt-4o-mini'
+param gptDeploymentName string = 'gpt-5.2-chat'
 
 @description('Capacity of the GPT deployment')
 // You can increase this, but capacity is limited per model/region, so you will get errors if you go over

--- a/src/quartapp/chat.py
+++ b/src/quartapp/chat.py
@@ -164,17 +164,18 @@ async def chat_handler(*, context):
             {"role": "system", "content": "You are a helpful assistant."},
         ] + request_messages
 
-        chat_coroutine = bp.openai_client.chat.completions.create(
-            # Azure Open AI takes the deployment name as the model name
+        chat_coroutine = bp.openai_client.responses.create(
             model=os.environ["AZURE_OPENAI_CHATGPT_DEPLOYMENT"],
-            messages=all_messages,
+            input=all_messages,
             stream=True,
+            store=False,
         )
         try:
             async for event in await chat_coroutine:
-                event_dict = event.model_dump()
-                if event_dict["choices"]:
-                    yield json.dumps(event_dict["choices"][0], ensure_ascii=False) + "\n"
+                if event.type == "response.output_text.delta":
+                    yield json.dumps({"delta": {"content": event.delta}}, ensure_ascii=False) + "\n"
+                elif event.type == "response.completed":
+                    yield json.dumps({"delta": {"content": None}, "finish_reason": "stop"}, ensure_ascii=False) + "\n"
         except Exception as e:
             current_app.logger.error(e)
             yield json.dumps({"error": str(e)}, ensure_ascii=False) + "\n"

--- a/src/quartapp/templates/index.html
+++ b/src/quartapp/templates/index.html
@@ -49,7 +49,7 @@
         </div>
 	</main>
     <script src="https://cdn.jsdelivr.net/npm/showdown@2.1.0/dist/showdown.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@microsoft/ai-chat-protocol@1.0.0-alpha.20240520.1/dist/iife/index.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/ndjson-readablestream@1.0.7/dist/ndjson-readablestream.umd.js"></script>
     <script>
         const form = document.getElementById("chat-form");
         const messageInput = document.getElementById("message");
@@ -58,8 +58,6 @@
         const assistantTemplate = document.querySelector('#message-template-assistant');
         const converter = new showdown.Converter();
         const messages = [];
-
-        const client = new ChatProtocol.AIChatProtocolClient("/chat");
 
         form.addEventListener("submit", async function(e) {
             e.preventDefault();
@@ -77,24 +75,28 @@
                 "role": "user",
                 "content": message
             });
-            const result = await client.getStreamedCompletion(messages);
+
+            const response = await fetch("/chat/stream", {
+                method: "POST",
+                headers: {"Content-Type": "application/json"},
+                body: JSON.stringify({messages: messages}),
+            });
 
             let answer = "";
-            for await (const response of result) {
-                if (!response.delta) {
+            for await (const chunk of readNDJSONStream(response.body)) {
+                if (!chunk.delta) {
                     continue;
                 }
-                if (response.delta.content) {
-                    // Clear out the DIV if its the first answer chunk we've received
+                if (chunk.delta.content) {
                     if (answer == "") {
                         messageDiv.innerHTML = "";
                     }
-                    answer += response.delta.content;
+                    answer += chunk.delta.content;
                     messageDiv.innerHTML = converter.makeHtml(answer);
                     messageDiv.scrollIntoView();
                 }
-                if (response.error) {
-                    messageDiv.innerHTML = "Error: " + response.error;
+                if (chunk.error) {
+                    messageDiv.innerHTML = "Error: " + chunk.error;
                 }
             }
             messages.push({

--- a/src/quartapp/templates/index.html
+++ b/src/quartapp/templates/index.html
@@ -84,6 +84,10 @@
 
             let answer = "";
             for await (const chunk of readNDJSONStream(response.body)) {
+                if (chunk.error) {
+                    messageDiv.innerHTML = "Error: " + chunk.error;
+                    break;
+                }
                 if (!chunk.delta) {
                     continue;
                 }
@@ -94,9 +98,6 @@
                     answer += chunk.delta.content;
                     messageDiv.innerHTML = converter.makeHtml(answer);
                     messageDiv.scrollIntoView();
-                }
-                if (chunk.error) {
-                    messageDiv.innerHTML = "Error: " + chunk.error;
                 }
             }
             messages.push({

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from . import mock_cred
 
 
 @pytest.fixture
-def mock_openai_chatcompletion(monkeypatch):
+def mock_openai_responses(monkeypatch):
     class MockResponseEvent:
         def __init__(self, event_type, delta=None):
             self.type = event_type
@@ -90,7 +90,7 @@ def mock_login_required(monkeypatch):
 @pytest_asyncio.fixture
 async def client(
     monkeypatch,
-    mock_openai_chatcompletion,
+    mock_openai_responses,
     mock_defaultazurecredential,
     mock_keyvault_secretclient,
     mock_login_required,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 from functools import wraps
 
 import identity.quart
-import openai
 import pytest
 import pytest_asyncio
 from azure.keyvault.secrets.aio import SecretClient
@@ -13,115 +12,41 @@ from . import mock_cred
 
 @pytest.fixture
 def mock_openai_chatcompletion(monkeypatch):
-    class AsyncChatCompletionIterator:
+    class MockResponseEvent:
+        def __init__(self, event_type, delta=None):
+            self.type = event_type
+            self.delta = delta
+
+    class AsyncResponseIterator:
         def __init__(self, answer: str):
-            self.chunk_index = 0
-            self.chunks = [
-                # This is an Azure-specific chunk solely for prompt_filter_results
-                openai.types.chat.ChatCompletionChunk(
-                    object="chat.completion.chunk",
-                    choices=[],
-                    id="",
-                    created=0,
-                    model="",
-                    prompt_filter_results=[
-                        {
-                            "prompt_index": 0,
-                            "content_filter_results": {
-                                "hate": {"filtered": False, "severity": "safe"},
-                                "self_harm": {"filtered": False, "severity": "safe"},
-                                "sexual": {"filtered": False, "severity": "safe"},
-                                "violence": {"filtered": False, "severity": "safe"},
-                            },
-                        }
-                    ],
-                ),
-                openai.types.chat.ChatCompletionChunk(
-                    id="test-123",
-                    object="chat.completion.chunk",
-                    choices=[
-                        openai.types.chat.chat_completion_chunk.Choice(
-                            delta=openai.types.chat.chat_completion_chunk.ChoiceDelta(content=None, role="assistant"),
-                            index=0,
-                            finish_reason=None,
-                            # Only Azure includes content_filter_results
-                            content_filter_results={},
-                        )
-                    ],
-                    created=1703462735,
-                    model="gpt-35-turbo",
-                ),
-            ]
-            answer_deltas = answer.split(" ")
-            for answer_index, answer_delta in enumerate(answer_deltas):
-                # Completion chunks include whitespace, so we need to add it back in
-                if answer_index > 0:
-                    answer_delta = " " + answer_delta
-                self.chunks.append(
-                    openai.types.chat.ChatCompletionChunk(
-                        id="test-123",
-                        object="chat.completion.chunk",
-                        choices=[
-                            openai.types.chat.chat_completion_chunk.Choice(
-                                delta=openai.types.chat.chat_completion_chunk.ChoiceDelta(
-                                    role=None, content=answer_delta
-                                ),
-                                finish_reason=None,
-                                index=0,
-                                logprobs=None,
-                                # Only Azure includes content_filter_results
-                                content_filter_results={
-                                    "hate": {"filtered": False, "severity": "safe"},
-                                    "self_harm": {"filtered": False, "severity": "safe"},
-                                    "sexual": {"filtered": False, "severity": "safe"},
-                                    "violence": {"filtered": False, "severity": "safe"},
-                                },
-                            )
-                        ],
-                        created=1703462735,
-                        model="gpt-35-turbo",
-                    )
-                )
-            self.chunks.append(
-                openai.types.chat.ChatCompletionChunk(
-                    id="test-123",
-                    object="chat.completion.chunk",
-                    choices=[
-                        openai.types.chat.chat_completion_chunk.Choice(
-                            delta=openai.types.chat.chat_completion_chunk.ChoiceDelta(content=None, role=None),
-                            index=0,
-                            finish_reason="stop",
-                            # Only Azure includes content_filter_results
-                            content_filter_results={},
-                        )
-                    ],
-                    created=1703462735,
-                    model="gpt-35-turbo",
-                )
-            )
+            self.event_index = 0
+            self.events = []
+            for i, word in enumerate(answer.split(" ")):
+                if i > 0:
+                    word = " " + word
+                self.events.append(MockResponseEvent("response.output_text.delta", delta=word))
+            self.events.append(MockResponseEvent("response.completed"))
 
         def __aiter__(self):
             return self
 
         async def __anext__(self):
-            if self.chunk_index < len(self.chunks):
-                next_chunk = self.chunks[self.chunk_index]
-                self.chunk_index += 1
-                return next_chunk
-            else:
-                raise StopAsyncIteration
+            if self.event_index < len(self.events):
+                event = self.events[self.event_index]
+                self.event_index += 1
+                return event
+            raise StopAsyncIteration
 
     async def mock_acreate(*args, **kwargs):
-        # Only mock a stream=True completion
-        last_message = kwargs.get("messages")[-1]["content"]
+        last_message = kwargs.get("input", [])[-1]["content"]
         if last_message == "What is the capital of France?":
-            return AsyncChatCompletionIterator("The capital of France is Paris.")
+            return AsyncResponseIterator("The capital of France is Paris.")
         elif last_message == "What is the capital of Germany?":
-            return AsyncChatCompletionIterator("The capital of Germany is Berlin.")
+            return AsyncResponseIterator("The capital of Germany is Berlin.")
         else:
             raise ValueError(f"Unexpected message: {last_message}")
 
-    monkeypatch.setattr("openai.resources.chat.AsyncCompletions.create", mock_acreate)
+    monkeypatch.setattr("openai.resources.responses.AsyncResponses.create", mock_acreate)
 
 
 @pytest.fixture

--- a/tests/snapshots/test_app/test_chat_stream_text/result.json
+++ b/tests/snapshots/test_app/test_chat_stream_text/result.json
@@ -1,8 +1,7 @@
-{"delta": {"content": null, "function_call": null, "refusal": null, "role": "assistant", "tool_calls": null}, "finish_reason": null, "index": 0, "logprobs": null, "content_filter_results": {}}
-{"delta": {"content": "The", "function_call": null, "refusal": null, "role": null, "tool_calls": null}, "finish_reason": null, "index": 0, "logprobs": null, "content_filter_results": {"hate": {"filtered": false, "severity": "safe"}, "self_harm": {"filtered": false, "severity": "safe"}, "sexual": {"filtered": false, "severity": "safe"}, "violence": {"filtered": false, "severity": "safe"}}}
-{"delta": {"content": " capital", "function_call": null, "refusal": null, "role": null, "tool_calls": null}, "finish_reason": null, "index": 0, "logprobs": null, "content_filter_results": {"hate": {"filtered": false, "severity": "safe"}, "self_harm": {"filtered": false, "severity": "safe"}, "sexual": {"filtered": false, "severity": "safe"}, "violence": {"filtered": false, "severity": "safe"}}}
-{"delta": {"content": " of", "function_call": null, "refusal": null, "role": null, "tool_calls": null}, "finish_reason": null, "index": 0, "logprobs": null, "content_filter_results": {"hate": {"filtered": false, "severity": "safe"}, "self_harm": {"filtered": false, "severity": "safe"}, "sexual": {"filtered": false, "severity": "safe"}, "violence": {"filtered": false, "severity": "safe"}}}
-{"delta": {"content": " France", "function_call": null, "refusal": null, "role": null, "tool_calls": null}, "finish_reason": null, "index": 0, "logprobs": null, "content_filter_results": {"hate": {"filtered": false, "severity": "safe"}, "self_harm": {"filtered": false, "severity": "safe"}, "sexual": {"filtered": false, "severity": "safe"}, "violence": {"filtered": false, "severity": "safe"}}}
-{"delta": {"content": " is", "function_call": null, "refusal": null, "role": null, "tool_calls": null}, "finish_reason": null, "index": 0, "logprobs": null, "content_filter_results": {"hate": {"filtered": false, "severity": "safe"}, "self_harm": {"filtered": false, "severity": "safe"}, "sexual": {"filtered": false, "severity": "safe"}, "violence": {"filtered": false, "severity": "safe"}}}
-{"delta": {"content": " Paris.", "function_call": null, "refusal": null, "role": null, "tool_calls": null}, "finish_reason": null, "index": 0, "logprobs": null, "content_filter_results": {"hate": {"filtered": false, "severity": "safe"}, "self_harm": {"filtered": false, "severity": "safe"}, "sexual": {"filtered": false, "severity": "safe"}, "violence": {"filtered": false, "severity": "safe"}}}
-{"delta": {"content": null, "function_call": null, "refusal": null, "role": null, "tool_calls": null}, "finish_reason": "stop", "index": 0, "logprobs": null, "content_filter_results": {}}
+{"delta": {"content": "The"}}
+{"delta": {"content": " capital"}}
+{"delta": {"content": " of"}}
+{"delta": {"content": " France"}}
+{"delta": {"content": " is"}}
+{"delta": {"content": " Paris."}}
+{"delta": {"content": null}, "finish_reason": "stop"}

--- a/tests/snapshots/test_app/test_chat_stream_text_history/result.json
+++ b/tests/snapshots/test_app/test_chat_stream_text_history/result.json
@@ -1,8 +1,7 @@
-{"delta": {"content": null, "function_call": null, "refusal": null, "role": "assistant", "tool_calls": null}, "finish_reason": null, "index": 0, "logprobs": null, "content_filter_results": {}}
-{"delta": {"content": "The", "function_call": null, "refusal": null, "role": null, "tool_calls": null}, "finish_reason": null, "index": 0, "logprobs": null, "content_filter_results": {"hate": {"filtered": false, "severity": "safe"}, "self_harm": {"filtered": false, "severity": "safe"}, "sexual": {"filtered": false, "severity": "safe"}, "violence": {"filtered": false, "severity": "safe"}}}
-{"delta": {"content": " capital", "function_call": null, "refusal": null, "role": null, "tool_calls": null}, "finish_reason": null, "index": 0, "logprobs": null, "content_filter_results": {"hate": {"filtered": false, "severity": "safe"}, "self_harm": {"filtered": false, "severity": "safe"}, "sexual": {"filtered": false, "severity": "safe"}, "violence": {"filtered": false, "severity": "safe"}}}
-{"delta": {"content": " of", "function_call": null, "refusal": null, "role": null, "tool_calls": null}, "finish_reason": null, "index": 0, "logprobs": null, "content_filter_results": {"hate": {"filtered": false, "severity": "safe"}, "self_harm": {"filtered": false, "severity": "safe"}, "sexual": {"filtered": false, "severity": "safe"}, "violence": {"filtered": false, "severity": "safe"}}}
-{"delta": {"content": " Germany", "function_call": null, "refusal": null, "role": null, "tool_calls": null}, "finish_reason": null, "index": 0, "logprobs": null, "content_filter_results": {"hate": {"filtered": false, "severity": "safe"}, "self_harm": {"filtered": false, "severity": "safe"}, "sexual": {"filtered": false, "severity": "safe"}, "violence": {"filtered": false, "severity": "safe"}}}
-{"delta": {"content": " is", "function_call": null, "refusal": null, "role": null, "tool_calls": null}, "finish_reason": null, "index": 0, "logprobs": null, "content_filter_results": {"hate": {"filtered": false, "severity": "safe"}, "self_harm": {"filtered": false, "severity": "safe"}, "sexual": {"filtered": false, "severity": "safe"}, "violence": {"filtered": false, "severity": "safe"}}}
-{"delta": {"content": " Berlin.", "function_call": null, "refusal": null, "role": null, "tool_calls": null}, "finish_reason": null, "index": 0, "logprobs": null, "content_filter_results": {"hate": {"filtered": false, "severity": "safe"}, "self_harm": {"filtered": false, "severity": "safe"}, "sexual": {"filtered": false, "severity": "safe"}, "violence": {"filtered": false, "severity": "safe"}}}
-{"delta": {"content": null, "function_call": null, "refusal": null, "role": null, "tool_calls": null}, "finish_reason": "stop", "index": 0, "logprobs": null, "content_filter_results": {}}
+{"delta": {"content": "The"}}
+{"delta": {"content": " capital"}}
+{"delta": {"content": " of"}}
+{"delta": {"content": " Germany"}}
+{"delta": {"content": " is"}}
+{"delta": {"content": " Berlin."}}
+{"delta": {"content": null}, "finish_reason": "stop"}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -58,7 +58,7 @@ async def test_openai_key(monkeypatch, mock_keyvault_secretclient):
 
 @pytest.mark.asyncio
 async def test_openai_managedidentity(monkeypatch, mock_keyvault_secretclient):
-    monkeypatch.setenv("AZURE_OPENAI_CLIENT_ID", "test-client-id")
+    monkeypatch.setenv("AZURE_CLIENT_ID", "test-client-id")
     monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "test-openai-service.openai.azure.com")
     monkeypatch.setenv("AZURE_OPENAI_CHATGPT_DEPLOYMENT", "test-chatgpt")
 


### PR DESCRIPTION
## Migrate from Chat Completions to Responses API

Migrates the app from Azure OpenAI Chat Completions to the Responses API, and upgrades the default model to `gpt-5.2-chat`.

### Changes

| File | What changed |
|---|---|
| `src/quartapp/chat.py` | `chat.completions.create(messages=...)` → `responses.create(input=..., store=False)`, streaming rewritten from `choices[0]` to `event.type`/`event.delta` |
| `src/quartapp/templates/index.html` | Replaced deprecated `@microsoft/ai-chat-protocol` CDN with `ndjson-readablestream`, replaced `AIChatProtocolClient` with direct `fetch()` |
| `tests/conftest.py` | `ChatCompletionChunk` mocks → `MockResponseEvent`/`AsyncResponseIterator`, monkeypatch path → `AsyncResponses.create`, `messages` → `input` |
| `tests/test_app.py` | `AZURE_OPENAI_CLIENT_ID` → `AZURE_CLIENT_ID` |
| `tests/snapshots/` (×2) | Simplified from full `choices[0]` shape to `{"delta": {"content": "..."}}` |
| `infra/main.bicep` | Default model upgraded from `gpt-4o-mini` to `gpt-5.2-chat` (2026-02-10) |

### Verification

- Scanner reports **zero** legacy Chat Completions hits
- All **6 tests pass** (98% coverage)
- Deployed and tested end-to-end on Azure Container Apps