### PR TITLE
Remove unused AZURE_CREDENTIALS secret reference

### DIFF
--- a/.github/workflows/azure-dev.yaml
+++ b/.github/workflows/azure-dev.yaml
@@ -23,7 +23,6 @@ jobs:
       AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-      AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
       # project specific
       AZURE_AUTH_TENANT_ID: ${{ vars.AZURE_AUTH_TENANT_ID }}
       AZURE_AUTH_CLIENT_ID: ${{ vars.AZURE_AUTH_CLIENT_ID }}


### PR DESCRIPTION
Removes the unused `AZURE_CREDENTIALS` secret reference from `azure-dev.yaml`.

The workflow authenticates to Azure exclusively via OIDC federated credentials (`azd auth login --federated-credential-provider github`). No step consumes `AZURE_CREDENTIALS`, so this reference is dead configuration. Removing it has no functional impact and keeps the workflow aligned with passwordless auth.

One-line deletion; no other changes.